### PR TITLE
Updated Outline Component with customizability

### DIFF
--- a/components/Outline.tsx
+++ b/components/Outline.tsx
@@ -1,8 +1,17 @@
 type OutlineProps = {
   className?: string;
+  largeSize: boolean;
   children: JSX.Element[];
 };
 
-export default function Outline({ className, children }: OutlineProps) {
-  return <div className="font-outline">{children}</div>;
+export default function Outline({
+  className,
+  children,
+  largeSize,
+}: OutlineProps) {
+  if (largeSize) {
+    return <div className="font-outline-large">{children}</div>;
+  } else {
+    return <div className="font-outline-small">{children}</div>;
+  }
 }

--- a/plasmic-init.ts
+++ b/plasmic-init.ts
@@ -171,5 +171,6 @@ PLASMIC.registerComponent(Outline, {
   props: {
     className: "string",
     children: "slot",
+    largeSize: "boolean",
   },
 });

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -133,7 +133,10 @@
 
 @layer base {
   /*Adds the font-outline Tailwind CSS property*/
-  .font-outline {
+  .font-outline-large {
     -webkit-text-stroke: 4px black;
+  }
+  .font-outline-small {
+    -webkit-text-stroke: 2px black;
   }
 }


### PR DESCRIPTION
Added the option for 4px shadow or 2px shadow in the Outline component. 4px shadow is intended for use with larger text where the shadow needs to be larger and 2px is inteded for smaller text. The prop is called "largeSize" and by checking the box, it will enlarge the shadow to 4px, else it is 2px by default